### PR TITLE
Fix typo in gem install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-    gem install puppet-catalog-tests
+    gem install puppet-catalog-test
 
 ## Usage
 ```bash


### PR DESCRIPTION
The gem name is singular.
