### PR TITLE
Update puppet-catalog-test.gemspec to remove puppet dependency

### DIFF
--- a/puppet-catalog-test.gemspec
+++ b/puppet-catalog-test.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.files += Dir["lib/**/*"]
 
-  s.add_dependency 'puppet'
   s.add_dependency 'parallel'
   s.add_dependency 'builder'
 


### PR DESCRIPTION
removing dependency on puppet, since puppet is already installed via rpm.

In my environment, we install puppet via RPM.  When I install puppet-catalog-test via gem, I end up with puppet installed via gem as well.

Since puppet recommends the RPM install, can we install via RPM, this allows more to use this great tool. (http://docs.puppetlabs.com/guides/installation.html#installing-from-gems-not-recommended)
