### PR TITLE
Update LOAD_PATH to support puppet modules containing plugins with requi...

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,1 +1,2 @@
+# Dummy commit
 - exclude nodes

--- a/TODO
+++ b/TODO
@@ -1,2 +1,1 @@
-# Dummy commit
 - exclude nodes

--- a/lib/puppet-catalog-test/test_runner.rb
+++ b/lib/puppet-catalog-test/test_runner.rb
@@ -22,7 +22,7 @@ module PuppetCatalogTest
       @exit_on_fail = true
       @out = stdout_target
 
-      
+
       if puppet_config[:xml]
 	 require 'puppet-catalog-test/junit_xml_reporter'
          @reporter = PuppetCatalogTest::JunitXmlReporter.new("puppet-catalog-test", "puppet_catalogs.xml")
@@ -66,6 +66,10 @@ module PuppetCatalogTest
       if hiera_config
         raise ArgumentError, "[ERROR] hiera_config  (#{hiera_config}) does not exist" if !FileTest.exist?(hiera_config)
         Puppet.settings[:hiera_config] = hiera_config
+      end
+
+      Puppet::Node::Environment.new.each_plugin_directory do |dir|
+        $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
       end
 
       Puppet.parse_config

--- a/puppet-catalog-test.gemspec
+++ b/puppet-catalog-test.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'puppet-catalog-test'
-  s.version = '0.3.1'
+  s.version = '0.3.1.1'
   s.homepage = 'https://github.com/invadersmustdie/puppet-catalog-test/'
   s.summary = 'Test all your puppet catalogs for compiler warnings and errors'
   s.description = 'Test all your puppet catalogs for compiler warnings and errors.'
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.files += Dir["lib/**/*"]
 
-  s.add_dependency 'puppet'
   s.add_dependency 'parallel'
   s.add_dependency 'builder'
 

--- a/test/cases/working/modules/myapp/lib/puppet/provider/test/test_provider.rb
+++ b/test/cases/working/modules/myapp/lib/puppet/provider/test/test_provider.rb
@@ -1,0 +1,3 @@
+require 'puppet/provider/will_be_required'
+Puppet::Type.type(:test).provide(:test_provider) do
+end

--- a/test/cases/working/modules/myapp/lib/puppet/provider/will_be_required.rb
+++ b/test/cases/working/modules/myapp/lib/puppet/provider/will_be_required.rb
@@ -1,0 +1,1 @@
+# This file will be required by our provider

--- a/test/cases/working/modules/myapp/lib/puppet/type/test.rb
+++ b/test/cases/working/modules/myapp/lib/puppet/type/test.rb
@@ -1,0 +1,2 @@
+Puppet::Type.newtype(:test) do
+end

--- a/test/cases/working/modules/myapp/manifests/init.pp
+++ b/test/cases/working/modules/myapp/manifests/init.pp
@@ -2,4 +2,6 @@ class myapp {
   package { "myapp-pkg":
     ensure => latest
   }
+
+  test { 'testing_requires':}
 }


### PR DESCRIPTION
LOAD_PATH is needed to allow modules with custom types/providers to use requires properly.