### PR TITLE
clear the state in Puppet::Settings

### DIFF
--- a/lib/puppet-catalog-test/test_runner.rb
+++ b/lib/puppet-catalog-test/test_runner.rb
@@ -18,6 +18,10 @@ module PuppetCatalogTest
         raise ArgumentError, "No puppet_config hash supplied"
       end
 
+      if Puppet::PUPPETVERSION.to_i >= 3
+        Puppet.settings.send(:clear_everything_for_tests)
+      end
+      
       @test_cases = []
       @exit_on_fail = true
       @out = stdout_target


### PR DESCRIPTION
- clear the state in Puppet::Settings to avoid "Puppet::DevError: Attempting to initialize global default settings more than once!" when multiple tests are run in sequence.