### PR TITLE
Ability to enable or disable future parser for Puppet 3.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ USAGE: puppet-catalog-test [options]
     -e, --exclude-pattern PATTERN    Exclude test cases that match pattern
     -s, --scenario FILE              Scenario definition to use
     -f, --fact KEY=VALUE             Add custom fact
-    -p, --parser (current|future)    Change puppet parser (3.x only)
+    -p, --parser (current|future)    Change puppet parser (3.2+ only)
     -v, --verbose                    Verbose
     -x, --xml                        Use xml report
     -h, --help                       Show this message

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ USAGE: puppet-catalog-test [options]
     -e, --exclude-pattern PATTERN    Exclude test cases that match pattern
     -s, --scenario FILE              Scenario definition to use
     -f, --fact KEY=VALUE             Add custom fact
+    -p, --parser (current|future)    Change puppet parser (3.x only)
     -v, --verbose                    Verbose
     -x, --xml                        Use xml report
     -h, --help                       Show this message
@@ -122,6 +123,23 @@ namespace :catalog do
     t.exclude_pattern = ENV["exclude"]
   end
 end
+```
+
+### Testing catalog with future parser
+```ruby
+require 'puppet-catalog-test'
+
+namespace :catalog do
+  PuppetCatalogTest::RakeTask.new(:scenarios) do |t|
+    t.module_paths = ["modules"]
+    t.manifest_path = File.join("scripts", "site.pp")
+
+    t.scenario_yaml = "scenarios.yml"
+    t.parser = "future"
+
+    t.include_pattern = ENV["include"]
+    t.exclude_pattern = ENV["exclude"]
+  end
 ```
 
 ## Scenario testing

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "rake/testtask"
 require "bundler/gem_tasks"
+require "puppet/version"
+require "rubygems"
 
 desc "Clean workspace"
 task :clean do
@@ -20,6 +22,9 @@ task :test_integration do
 
   Dir["test/**/Rakefile"].each do |rf|
     supposed_to_fail = rf.include?("failing")
+    if rf.include?("future-parser")
+      supposed_to_fail = Gem::Version.new(Puppet.version) > Gem::Version.new('3.2.0')
+    end
     Dir.chdir rf.split("/")[0..-2].join("/")
 
     ["catalog:scenarios", "catalog:all"].each do |tc|

--- a/bin/puppet-catalog-test
+++ b/bin/puppet-catalog-test
@@ -42,6 +42,10 @@ opt_parser = OptionParser.new do |opts|
     options[:custom_facts][k] = v
   end
 
+  opts.on("-p", "--parser (current|future)", "Change puppet parser (3.x only)") do |arg|
+    options[:parser] = arg
+  end
+
   opts.on("-v", "--verbose", "Verbose") do |arg|
     options[:verbose] = true
   end
@@ -68,6 +72,7 @@ pct = PuppetCatalogTest::TestRunner.new(
   :module_paths => options[:module_paths],
   :hiera_config => options[:hiera_config],
   :verbose => options[:verbose],
+  :parser => options[:parser],
   :xml => options[:xml])
 
 filter = PuppetCatalogTest::Filter.new

--- a/bin/puppet-catalog-test
+++ b/bin/puppet-catalog-test
@@ -42,7 +42,7 @@ opt_parser = OptionParser.new do |opts|
     options[:custom_facts][k] = v
   end
 
-  opts.on("-p", "--parser (current|future)", "Change puppet parser (3.x only)") do |arg|
+  opts.on("-p", "--parser (current|future)", "Change puppet parser (3.2+ only)") do |arg|
     options[:parser] = arg
   end
 

--- a/lib/puppet-catalog-test.rb
+++ b/lib/puppet-catalog-test.rb
@@ -1,5 +1,5 @@
 module PuppetCatalogTest
-  VERSION = "0.2.2"
+  VERSION = "0.4.1"
 
   DEFAULT_FILTER = /.*/
 

--- a/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
@@ -6,9 +6,10 @@ module PuppetCatalogTest
       super(config)
 
       require 'puppet/test/test_helper'
+      parser = config[:parser]
 
-      # works 3.7.x
-      if version.start_with?("3.7.")
+      # works 3.x
+      if version.start_with?("3.")
         Puppet::Test::TestHelper.initialize
       end
 
@@ -17,6 +18,13 @@ module PuppetCatalogTest
           ldir = entry.plugin_directory
           $LOAD_PATH << ldir unless $LOAD_PATH.include?(ldir)
         end
+      end
+
+      if parser
+        parser_regex = /^(current|future)$/
+        raise ArgumentError, "[ERROR] parser (#{parser}) is not a valid parser, should be 'current' or 'future'" if !parser.match(parser_regex)
+        puts "[INFO] Using #{parser} puppet parser"
+        Puppet.settings[:parser] = parser
       end
 
       Puppet.parse_config

--- a/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
@@ -1,4 +1,5 @@
 require "puppet"
+require "rubygems"
 
 module PuppetCatalogTest
   class Puppet3xAdapter < BasePuppetAdapter
@@ -8,8 +9,8 @@ module PuppetCatalogTest
       require 'puppet/test/test_helper'
       parser = config[:parser]
 
-      # works 3.x
-      if version.start_with?("3.")
+      # initialize was added in 3.1.0
+      if Gem::Version.new(version) > Gem::Version.new('3.1.0')
         Puppet::Test::TestHelper.initialize
       end
 
@@ -20,7 +21,8 @@ module PuppetCatalogTest
         end
       end
 
-      if parser
+      # future parser was added in 3.2.0
+      if parser and Gem::Version.new(version) > Gem::Version.new('3.2.0')
         parser_regex = /^(current|future)$/
         raise ArgumentError, "[ERROR] parser (#{parser}) is not a valid parser, should be 'current' or 'future'" if !parser.match(parser_regex)
         puts "[INFO] Using #{parser} puppet parser"

--- a/lib/puppet-catalog-test/rake_task.rb
+++ b/lib/puppet-catalog-test/rake_task.rb
@@ -5,14 +5,15 @@ module PuppetCatalogTest
   class RakeTask < ::Rake::TaskLib
     include ::Rake::DSL if defined?(::Rake::DSL)
 
-    attr_accessor :module_paths
-    attr_accessor :manifest_path
     attr_accessor :config_dir
-    attr_accessor :scenario_yaml
-    attr_accessor :include_pattern
     attr_accessor :exclude_pattern
     attr_accessor :facts
+    attr_accessor :include_pattern
+    attr_accessor :manifest_path
+    attr_accessor :module_paths
+    attr_accessor :parser
     attr_accessor :reporter
+    attr_accessor :scenario_yaml
     attr_accessor :verbose
 
     def initialize(name, &task_block)
@@ -26,9 +27,10 @@ module PuppetCatalogTest
 
     def setup
       puppet_config = {
+        :config_dir => @config_dir,
         :manifest_path => @manifest_path,
         :module_paths => @module_paths,
-        :config_dir => @config_dir,
+        :parser => @parser,
         :verbose => @verbose
       }
 

--- a/puppet-catalog-test.gemspec
+++ b/puppet-catalog-test.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'puppet-catalog-test'
-  s.version = '0.4.0'
+  s.version = '0.4.1'
   s.homepage = 'https://github.com/invadersmustdie/puppet-catalog-test/'
   s.summary = 'Test all your puppet catalogs for compiler warnings and errors'
   s.description = 'Test all your puppet catalogs for compiler warnings and errors.'

--- a/test/cases/failing-with-future-parser/Rakefile
+++ b/test/cases/failing-with-future-parser/Rakefile
@@ -1,0 +1,24 @@
+$:.unshift("../../../lib")
+require 'puppet-catalog-test'
+
+namespace :catalog do
+  PuppetCatalogTest::RakeTask.new(:scenarios) do |t|
+    t.module_paths = [File.join("modules")]
+    t.manifest_path = File.join("site.pp")
+
+    t.scenario_yaml = "scenarios.yml"
+    t.parser = "future"
+
+    t.include_pattern = ENV["include"]
+    t.exclude_pattern = ENV["exclude"]
+  end
+
+  PuppetCatalogTest::RakeTask.new(:all) do |t|
+    t.module_paths = [File.join("modules")]
+    t.manifest_path = File.join("site.pp")
+    t.parser = "future"
+
+    t.include_pattern = ENV["include"]
+    t.exclude_pattern = ENV["exclude"]
+  end
+end

--- a/test/cases/failing-with-future-parser/modules/myapp/manifests/init.pp
+++ b/test/cases/failing-with-future-parser/modules/myapp/manifests/init.pp
@@ -1,0 +1,6 @@
+class myapp {
+  package { "myapp-pkg":
+    ensure => latest
+  }
+  if true { }
+}

--- a/test/cases/failing-with-future-parser/scenarios.yml
+++ b/test/cases/failing-with-future-parser/scenarios.yml
@@ -1,0 +1,5 @@
+foo:
+  fqdn: foo.local
+
+bar:
+  fqdn: bar.local

--- a/test/cases/failing-with-future-parser/site.pp
+++ b/test/cases/failing-with-future-parser/site.pp
@@ -1,0 +1,7 @@
+node "foo" {
+  include myapp
+}
+
+node default {
+  include myapp
+}


### PR DESCRIPTION
This adds the flag to the command line program `-p`, `--parser` or in the Rake context, `parser`.
All tests pass (Puppet 3.8, Ruby 2.0.0) and I included a new integration test.

This also fixes the issue that #21 was seeing, the tests wouldn't pass (Puppet 3.8) without that change.

I'd love a merge and a push to rubygems. Thanks!