### PR TITLE
Merge facts into node when using Puppet 4.x.

### DIFF
--- a/lib/puppet-catalog-test/puppet_adapter/puppet_4x_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/puppet_4x_adapter.rb
@@ -28,7 +28,9 @@ module PuppetCatalogTest
     end
 
     def create_node(hostname, facts)
-      Puppet::Node.new(hostname, :facts => Puppet::Node::Facts.new("facts", facts))
+      node = Puppet::Node.new(hostname, :facts => Puppet::Node::Facts.new("facts", facts))
+      node.merge(facts)
+      node
     end
 
     def compile(node)

--- a/test/cases/working-with-facts/Rakefile
+++ b/test/cases/working-with-facts/Rakefile
@@ -1,0 +1,24 @@
+$:.unshift("../../../lib")
+require 'puppet-catalog-test'
+
+namespace :catalog do
+  PuppetCatalogTest::RakeTask.new(:scenarios) do |t|
+    t.module_paths = [File.join("modules")]
+    t.manifest_path = File.join("site.pp")
+
+    t.scenario_yaml = "scenarios.yml"
+
+    t.include_pattern = ENV["include"]
+    t.exclude_pattern = ENV["exclude"]
+  end
+
+  PuppetCatalogTest::RakeTask.new(:all) do |t|
+    t.module_paths = [File.join("modules")]
+    t.manifest_path = File.join("site.pp")
+
+    t.include_pattern = ENV["include"]
+    t.exclude_pattern = ENV["exclude"]
+
+    t.verbose = true
+  end
+end

--- a/test/cases/working-with-facts/modules/myapp/manifests/init.pp
+++ b/test/cases/working-with-facts/modules/myapp/manifests/init.pp
@@ -1,0 +1,6 @@
+class myapp {
+  package { "myapp-pkg":
+    ensure => latest
+  }
+  unless $fqdn { fail('$fqdn unset') }
+}

--- a/test/cases/working-with-facts/scenarios.yml
+++ b/test/cases/working-with-facts/scenarios.yml
@@ -1,0 +1,2 @@
+test01:
+  fqdn: foo.local

--- a/test/cases/working-with-facts/scenarios_with_underscores.yml
+++ b/test/cases/working-with-facts/scenarios_with_underscores.yml
@@ -1,0 +1,2 @@
+__foo:
+  fqdn: foo.local

--- a/test/cases/working-with-facts/site.pp
+++ b/test/cases/working-with-facts/site.pp
@@ -1,0 +1,7 @@
+node "foo" {
+  unless $fqdn { fail('$fqdn unset') }
+}
+
+node default {
+  include myapp
+}

--- a/test/complete_catalog_test.rb
+++ b/test/complete_catalog_test.rb
@@ -12,6 +12,17 @@ class CompleteCatalogTest < PuppetCatalogTestCase
     assert_equal 2, pct.test_cases.select { |tc| tc.passed == true }.size
   end
 
+  def test_all_with_working_catalog_should_have_facts
+    pct = build_test_runner_for_all_nodes(File.join(CASE_DIR, "working-with-facts"))
+
+    assert_equal 2, pct.test_cases.size
+
+    result = pct.run_tests!
+    assert result
+
+    assert_equal 2, pct.test_cases.select { |tc| tc.passed == true }.size
+  end
+
   def test_all_with_broken_catalog_should_fail
     pct = build_test_runner_for_all_nodes(File.join(CASE_DIR, "failing"))
 


### PR DESCRIPTION
This fixes #24.

I'm not really sure if I did the right thing with the new test, but it fails without the fix and passes with it.