### PR TITLE
Support Rake 11.0

### DIFF
--- a/lib/puppet-catalog-test/rake_task.rb
+++ b/lib/puppet-catalog-test/rake_task.rb
@@ -17,7 +17,7 @@ module PuppetCatalogTest
     attr_accessor :verbose
 
     def initialize(name, &task_block)
-      desc "Compile all puppet catalogs" unless ::Rake.application.last_comment
+      desc "Compile all puppet catalogs" unless ::Rake.application.last_description
 
       task name do
         task_block.call(self) if task_block


### PR DESCRIPTION
Rake 11.0 (released today) includes the following in its release notes:

> * Removed Rake::TaskManager#last_comment. Use last_description.

This breaks puppet-catalog-test's rake task.