### PR TITLE
Fix ordering of TestHelper.before_each_test

### DIFF
--- a/lib/puppet-catalog-test/puppet_adapter/base_puppet_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/base_puppet_adapter.rb
@@ -3,6 +3,10 @@ require "puppet"
 module PuppetCatalogTest
   class BasePuppetAdapter
     def initialize(config)
+      @config = config
+    
+    def init_config()
+      config = @config
       manifest_path = config[:manifest_path]
       module_paths = config[:module_paths]
       config_dir = config[:config_dir]

--- a/lib/puppet-catalog-test/puppet_adapter/base_puppet_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/base_puppet_adapter.rb
@@ -4,6 +4,7 @@ module PuppetCatalogTest
   class BasePuppetAdapter
     def initialize(config)
       @config = config
+    end
     
     def init_config()
       config = @config

--- a/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
@@ -9,6 +9,8 @@ module PuppetCatalogTest
       require 'puppet/test/test_helper'
       parser = config[:parser]
 
+      init_config
+      
       # initialize was added in 3.1.0
       if Gem::Version.new(version) > Gem::Version.new('3.1.0')
         Puppet::Test::TestHelper.initialize

--- a/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
@@ -14,6 +14,8 @@ module PuppetCatalogTest
         Puppet::Test::TestHelper.initialize
       end
 
+      Puppet::Test::TestHelper.before_all_tests
+      
       Puppet::Node::Environment.new.modules_by_path.each do |_, mod|
         mod.entries.each do |entry|
           ldir = entry.plugin_directory
@@ -50,6 +52,7 @@ module PuppetCatalogTest
 
     def create_node(hostname, facts)
       Puppet::Test::TestHelper.before_each_test
+      init_config
       node = Puppet::Node.new(hostname)
       node.merge(facts)
       node

--- a/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/puppet_3x_adapter.rb
@@ -39,7 +39,6 @@ module PuppetCatalogTest
 
     def compile(node)
       begin
-        Puppet::Test::TestHelper.before_each_test
         catalog = Puppet::Parser::Compiler.compile(node)
         validate_relationships(catalog)
       rescue => e
@@ -50,6 +49,7 @@ module PuppetCatalogTest
     end
 
     def create_node(hostname, facts)
+      Puppet::Test::TestHelper.before_each_test
       node = Puppet::Node.new(hostname)
       node.merge(facts)
       node

--- a/lib/puppet-catalog-test/puppet_adapter/puppet_4x_adapter.rb
+++ b/lib/puppet-catalog-test/puppet_adapter/puppet_4x_adapter.rb
@@ -28,6 +28,8 @@ module PuppetCatalogTest
     end
 
     def create_node(hostname, facts)
+      Puppet::Test::TestHelper.before_each_test
+      init_config
       node = Puppet::Node.new(hostname, :facts => Puppet::Node::Facts.new("facts", facts))
       node.merge(facts)
       node
@@ -35,7 +37,6 @@ module PuppetCatalogTest
 
     def compile(node)
       begin
-        Puppet::Test::TestHelper.before_each_test
         Puppet::Parser::Compiler.compile(node)
       rescue => e
         raise e

--- a/lib/puppet-catalog-test/puppet_adapter_factory.rb
+++ b/lib/puppet-catalog-test/puppet_adapter_factory.rb
@@ -11,6 +11,8 @@ module PuppetCatalogTest
         return Puppet3xAdapter.new(config)
       elsif Puppet.version.start_with?("4.")
         return Puppet4xAdapter.new(config)
+      elsif Puppet.version.start_with?("5.")
+        return Puppet4xAdapter.new(config)
       end
 
       raise RuntimeException, "Unsupported Puppet version detected (#{Puppet.version})"


### PR DESCRIPTION
TestHelper.before_each_test need to be called before each test we submit
to puppet, that means implicitly to call it even before we create the
node under test. Calling it only before a compiler run is wrong
behaviour.

For me the old behaviour errors out.

root@f3d0f439e68e:/puppet_config# ruby --version
ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]

root@f3d0f439e68e:/puppet_config# puppet --version
3.8.5

If this is needed I can provide the docker container definition to reproduce.