### PR TITLE
Puppet 5.x support

### DIFF
--- a/lib/puppet-catalog-test/puppet_adapter_factory.rb
+++ b/lib/puppet-catalog-test/puppet_adapter_factory.rb
@@ -9,7 +9,7 @@ module PuppetCatalogTest
     def self.create_adapter(config)
       if Puppet.version.start_with?("3.")
         return Puppet3xAdapter.new(config)
-      elsif Puppet.version.start_with?("4.")
+      elsif Puppet.version =~ /^(4|5)/
         return Puppet4xAdapter.new(config)
       end
 

--- a/lib/puppet-catalog-test/test_runner.rb
+++ b/lib/puppet-catalog-test/test_runner.rb
@@ -99,7 +99,7 @@ module PuppetCatalogTest
       run_start = Time.now
       proc_count = Parallel.processor_count
 
-      processed_test_cases = Parallel.map(@test_cases, :in_processes => proc_count) do |tc|
+      processed_test_cases = Parallel.map(@test_cases, :in_processes => proc_count, :isolation => true) do |tc|
         begin
           tc_start_time = Time.now
 


### PR DESCRIPTION
With Puppet 5.x, we've been seeing erratic behaviour. When running multiple nodes, tests that should be failing are seeing false positives; it looks as though this is down to caching within Puppet, even though the test helpers are being used correctly.

Setting `:isolation => true` within the `Parallel.map` call appears to fix this, and still executes the tests in parallel.

