### PR TITLE
Support Puppet 6

### DIFF
--- a/lib/puppet-catalog-test/puppet_adapter_factory.rb
+++ b/lib/puppet-catalog-test/puppet_adapter_factory.rb
@@ -13,6 +13,8 @@ module PuppetCatalogTest
         return Puppet4xAdapter.new(config)
       elsif Puppet.version.start_with?("5.")
         return Puppet4xAdapter.new(config)
+      elsif Puppet.version.start_with?("6.")
+        return Puppet4xAdapter.new(config)
       end
 
       raise RuntimeException, "Unsupported Puppet version detected (#{Puppet.version})"


### PR DESCRIPTION
The Puppet 4 loaders appear to work ok with Puppet 6